### PR TITLE
Fix $GITHUB_SHA in coverage upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         ruby -e "$(curl -s https://undercover-ci.com/uploader.rb)" -- \
           --repo $GITHUB_REPOSITORY \
-          --commit $GITHUB_SHA \
+          --commit ${{ github.event.pull_request.head.sha }} \
           --lcov coverage/lcov/undercoverci_demo_ruby.lcov
 
     - name: Setup upterm session

--- a/lib/undercoverci_demo_ruby.rb
+++ b/lib/undercoverci_demo_ruby.rb
@@ -17,6 +17,10 @@ module UndercoverciDemoRuby
     def self.uncovered2
       "uncovered2"
     end
+
+    def self.uncovered_not_on_master
+      "I am a new method and have no tests"
+    end
   end
 
   class Two


### PR DESCRIPTION
Hi! I think there is a problem with values returned by `GITHUB_SHA` for `pull_request` events. I have to update the documentation, but here's a setup that should work for you. I will also update the uploader script to produce more useful output on errors!

https://github.community/t/github-sha-not-the-same-as-the-triggering-commit/18286/2